### PR TITLE
Drop status from bikeracks table

### DIFF
--- a/src/bikeracks/bikes.py
+++ b/src/bikeracks/bikes.py
@@ -85,36 +85,4 @@ def get_single_rack():
     
     return rack
 
-@bikes.route('/update_rack_status', methods=['GET'])
-def update_rack_status():
-    # update a rack's status (approved, not_approved) based on the upvote_count
-    # and downvote_count percentages
-   
-    rack_id = request.args.get('rack_id', type=int)
-    
-    if not rack_id:
-        return "No rack_id specified", 400
-    
-    db = get_db()
-    percentages = helper.get_count_percentage(rack_id, db)
-    
-    upvote = percentages['upvote_percentage']
-    downvote = percentages['downvote_percentage']
-    
-    
-    
-    current_rack_status = db.execute(
-        "SELECT rack_id from bikeracks where upvote_count > downvote_count").fetchone()
-    current_rack_status = helper.dict_from_row(current_rack_status)
-    current_rack_status = current_rack_status['status']
-    
-    new_rack_status = "approved" if upvote >= downvote else "not_approved"
-    
-    if new_rack_status != current_rack_status:
-        with db as cursor:
-            cursor.execute('''
-                UPDATE bikeracks SET status=?
-                WHERE rack_id=?''', (new_rack_status, rack_id,))
 
-    return "", 200
-    

--- a/src/bikeracks/bikes.py
+++ b/src/bikeracks/bikes.py
@@ -69,17 +69,6 @@ def get_racks():
     return racks
 
  
-@bikes.route('/store_rack/', methods=['POST'])
-def store_rack():
-    # manually insert racks into db   
-
-    args = request.json
-    db = get_db()
-    
-    helper.insert_rack(db, args)
-    return Response(status=200)
-
- 
 @bikes.route('/get_single_rack', methods=['GET'])
 def get_single_rack():
     # get rack based on rack_id 

--- a/src/bikeracks/bikes.py
+++ b/src/bikeracks/bikes.py
@@ -112,8 +112,10 @@ def update_rack_status():
     upvote = percentages['upvote_percentage']
     downvote = percentages['downvote_percentage']
     
-    current_rack_status = db.execute("SELECT status FROM bikeracks WHERE rack_id=?",
-        (rack_id,)).fetchone()
+    
+    
+    current_rack_status = db.execute(
+        "SELECT rack_id from bikeracks where upvote_count > downvote_count").fetchone()
     current_rack_status = helper.dict_from_row(current_rack_status)
     current_rack_status = current_rack_status['status']
     

--- a/src/bikeracks/helpers.py
+++ b/src/bikeracks/helpers.py
@@ -59,6 +59,8 @@ def get_racks(database, status, user_id):
     # based on status of rack ('not_approved', 'approved')
     # return a response object with the application/json mimetype, the content
     # is an array of dictionary objects that contain the states of each rack
+    
+    # what status is this rack
 
     if not status and not user_id:
         # get all racks from bikeracks table

--- a/src/bikeracks/schema.sql
+++ b/src/bikeracks/schema.sql
@@ -1,6 +1,7 @@
 /* The sqlite database schema */
 /* Why is 'status' blue 
 There are actually 2 states a bikerack can be in: "approved" or "not_approved"
+which will be calculated by using downvote_count and upvote_count
 separate table for votes, has foreign key on bike rack id
 and this separate table has the data for voting: type of vote (1 ("upvote") or -1 ("downvote")),
 user_id, index on the bikerack id (or user_id)
@@ -20,14 +21,12 @@ DROP TABLE IF EXISTS votes_history;
 
 CREATE TABLE bikeracks (
     rack_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    status TEXT DEFAULT "not_approved",
     latitude REAL NOT NULL,
     longitude REAL NOT NULL,
     address TEXT,
     upvote_count INTEGER NOT NULL DEFAULT 0,
     downvote_count INTEGER NOT NULL DEFAULT 0,
-    CONSTRAINT coordinates UNIQUE(latitude, longitude),
-    CHECK (status in ("approved", "not_approved"))
+    CONSTRAINT coordinates UNIQUE(latitude, longitude)
     
 );
 
@@ -61,12 +60,10 @@ that way we can link old votes back to their bikerack */
 
 CREATE TABLE bikeracks_history (
     rack_id INTEGER PRIMARY KEY,
-    status TEXT DEFAULT "not_approved",
     latitude REAL NOT NULL,
     longitude REAL NOT NULL,
     address TEXT,
-    CONSTRAINT coordinates UNIQUE(latitude, longitude),
-    CHECK (status in ("approved", "not_approved"))
+    CONSTRAINT coordinates UNIQUE(latitude, longitude)
 );
 
 /* 
@@ -90,13 +87,5 @@ CREATE TABLE votes_history (
 /*want to be able to look up votes from a certain period in time */
 CREATE UNIQUE INDEX old_votes ON votes_history (vote_timestamp);
 
-/* TODO Things to check:
-- check that the foreign key on the regular tables bikeracks and votes works 
-- add all bikeracks to the bikeracks_history 
-- then you can have foreign key on it in votes_history
-
-TODO this weekend:
-- ask about users table, and foreign key idea
-*/
 
 

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -19,7 +19,7 @@ class BikeRack {
         let markerColor,
             status = this.state.upvote_count > this.state.downvote_count;
             
-        markerColor = status? approvedMarkerColor : notApprovedMarkerColor;
+        markerColor = status ? approvedMarkerColor : notApprovedMarkerColor;
        
         this.state.markerColor = markerColor;
         

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -18,14 +18,9 @@ class BikeRack {
         // based on upvote and downvote count
         let markerColor,
             status = this.state.upvote_count > this.state.downvote_count;
-        
-        if (status) {
-            markerColor = approvedMarkerColor;
-        }
-        else if (!status) {
-            markerColor = notApprovedMarkerColor;
-        }
-        
+            
+        markerColor = status? approvedMarkerColor : notApprovedMarkerColor;
+       
         this.state.markerColor = markerColor;
         
         return markerColor;

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -16,10 +16,9 @@ class BikeRack {
 
     setMarkerColor() {
         // based on upvote and downvote count
-        let markerColor,
-            status = this.state.upvote_count > this.state.downvote_count;
+        let markerColor;
             
-        markerColor = status ? approvedMarkerColor : notApprovedMarkerColor;
+        markerColor = isApproved(state) ? approvedMarkerColor : notApprovedMarkerColor;
        
         this.state.markerColor = markerColor;
         
@@ -40,6 +39,11 @@ function buildMarkerIcon(markerColor) {
         markerColor: markerColor
     });
 };
+
+function isApproved(state) {
+    // returns true if a rack is approved (more upvotes than downvotes)
+    return state.upvote_count > state.downvote_count;
+}
 
 
 // -------------------------------@-------------------------------------

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -64,28 +64,7 @@ function getRack(state) {
         
 }
 
-// for testing purposes
-function storeRack(state) {
-    
-    $.ajax({
-        method: 'POST',
-        url: {{ url_for('bikes.store_rack')|tojson }},
-        data: JSON.stringify({
-            latitude: state.latitude,
-            longitude: state.longitude,
-            status: state.status,
-            address: state.address,
-            upvote_count: state.vote.upvote,
-            downvote_count: state.vote.downvote
-        }, null, '\t'),
-        dataType: 'json',
-        contentType: 'application/json;charset=UTF-8',
-        context: this
-    }).done((data) => {
-        console.log("printing data:");
-        console.log(data);
-    })
-}
+
 
 
 

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -17,12 +17,12 @@ class BikeRack {
     setMarkerColor() {
         // based on upvote and downvote count
         let markerColor,
-            status = this.state.status;
+            status = this.state.upvote_count > this.state.downvote_count;
         
-        if (status === "approved") {
+        if (status) {
             markerColor = approvedMarkerColor;
         }
-        else if (status === "not_approved") {
+        else if (!status) {
             markerColor = notApprovedMarkerColor;
         }
         

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -45,6 +45,15 @@ function isApproved(state) {
     return state.upvote_count > state.downvote_count;
 }
 
+function isTemporary(state) {
+    // returns true if a rack is a temporary rack (does not have a rack_id)
+    return !state.rack_id;
+}
+
+function isLoggedIn(bikemap) {
+    return Boolean(bikemap.auth.currentUser);
+}
+
 
 // -------------------------------@-------------------------------------
 // for testing purposes

--- a/src/bikeracks/templates/helpers.js
+++ b/src/bikeracks/templates/helpers.js
@@ -18,7 +18,7 @@ class BikeRack {
         // based on upvote and downvote count
         let markerColor;
             
-        markerColor = isApproved(state) ? approvedMarkerColor : notApprovedMarkerColor;
+        markerColor = isApproved(this.state) ? approvedMarkerColor : notApprovedMarkerColor;
        
         this.state.markerColor = markerColor;
         

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -609,8 +609,8 @@ BikeMap.prototype.popupContent = function(state) {
      *     address: address (string),
      *     latitude: latitude (string),
      *     longitude: longitude (string),
-     *     rack_id: rack_id (string),
-     *     status: string (is it a temp marker or not, can be determined based on whether this rack has a status or not),
+     *     rack_id: rack_id (string), determine if a marker is a temporary marker
+     * or not by if they have a rack_id or not
      *     user_id: user_id (string, empty? (or undefined) if user is not signed in)
     }*/
     if (state.address === null || state.address === undefined) {
@@ -624,14 +624,14 @@ BikeMap.prototype.popupContent = function(state) {
                <div id="options">`
     
     // if user is online and this isn't a temporary marker include the submit button and the voting buttons
-    if (onlineStatus && state.status) {
+    if (onlineStatus && state.rack_id) {
         
         let arrows = this.arrowHTML(state);
         //content += `<button id="submitButton" type="submit">Add Bike Rack</button>`
         content += arrows;
     }
     // if the user is online and this IS a temporary marker include only the submit button
-    else if (onlineStatus && !state.status && state.address) {
+    else if (onlineStatus && !state.rack_id && state.address) {
         
         content += `<button id="submitButton" type="submit">Add Bike Rack</button>`
     }

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -364,6 +364,7 @@ BikeMap.prototype.createMarker = function(state) {
         let status = state.upvote_count > state.downvote_count;
         // add marker to allRacks feature group and its feature group based on status
         this.allRacks.addLayer(marker);
+        // true implies that this rack is approved
         if (status) {
             this.allApproved.addLayer(marker);
         }

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -518,7 +518,7 @@ BikeMap.prototype.vote = function(e) {
         else {
             // user is voting for rack for the first time
             let voteType = e.target.dataset.votetype;
-            voteType = voteType === "upvote"? 1 : -1;
+            voteType = voteType === "upvote" ? 1 : -1;
             
             this.submitVote(rack_id, user_id, voteType).done(vote => {
                     this.loadMap(user_id);

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -590,7 +590,7 @@ BikeMap.prototype.popupContent = function(state) {
      *     latitude: latitude (string),
      *     longitude: longitude (string),
      *     rack_id: rack_id (string), determine if a marker is a temporary marker
-     * or not by if they have a rack_id or not
+     *         or not by if they have a rack_id or not
      *     user_id: user_id (string, empty? (or undefined) if user is not signed in)
     }*/
     if (state.address === null || state.address === undefined) {

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -458,17 +458,6 @@ BikeMap.prototype.submitVote = function(rack_id, user_id, vote_type) {
     })
 }
 
-BikeMap.prototype.updateRackStatus = function(rack_id) {
-    let params = $.param({rack_id: rack_id}),
-        path = {{ url_for('bikes.update_rack_status')|tojson }};
-    
-    return $.ajax({
-        method: 'GET',
-        url: path + '?' + params,
-        context: this,
-        })
-}
-
 BikeMap.prototype.unvote = function(voteType, rack_id, user_id) {
     // Remove a vote of voteType for rack with rackId and for user with userId
     

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -518,10 +518,7 @@ BikeMap.prototype.vote = function(e) {
             if (voteType === 1 && newVoteType === -1 || voteType === -1 && newVoteType === 1) {
                 
                 this.submitVote(rack_id, user_id, newVoteType).done(vote => {
-                    this.updateRackStatus(rack_id).done(status => {
-                        
                         this.loadMap(user_id);
-                    });
                 });
             }
             // if the new vote is the same as the old vote, UNVOTE
@@ -538,10 +535,7 @@ BikeMap.prototype.vote = function(e) {
             voteType = voteType === "upvote"? 1 : -1;
             
             this.submitVote(rack_id, user_id, voteType).done(vote => {
-                this.updateRackStatus(rack_id).done(status => {
-                    
                     this.loadMap(user_id);
-                });
             });
         }
     })

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -244,8 +244,6 @@ BikeMap.prototype.submitBikeRack = function(e, callback) {
         // place on the map that was clicked
         
         // submit a location on the map for bike rack location consideration
-        // it will be added to the database with a status of pending
-        // as long as the coordinates are valid
         e.preventDefault();
         $.ajax({
             method: 'POST',

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -142,9 +142,7 @@ BikeMap.prototype.onAuthStateChanged = function(user) {
         // hide sign in button
         this.$signInButton.attr('hidden', true);
         
-        // TODO load map with UI for online users (buttons available for
-        // submitting and voting)
-        
+
         // first things first, reload the map TODO
         this.loadMap(user.uid); 
         
@@ -290,7 +288,6 @@ BikeMap.prototype.onMapClick = function (e) {
             longitude: e.latlng.lng,
             address: address,
             rackId: "",
-            status: undefined,
             upvoteCount: undefined,
             downvoteCount: undefined,
             userId: userId,
@@ -323,7 +320,6 @@ BikeMap.prototype.addTempMarker = function(lat, lng, address) {
             latitude: lat,
             longitude: lng,
             address: address,
-            status: undefined,
             rackId: "",
             upvoteCount: undefined,
             downvoteCount: undefined,
@@ -366,13 +362,14 @@ BikeMap.prototype.createMarker = function(state) {
     else {
         // we didn't find a marker, make a new one
         marker = L.marker([state.latitude, state.longitude], {uniqueId: state.rack_id}); 
-        
+        // Figure out marker's status
+        let status = state.upvote_count > state.downvote_count;
         // add marker to allRacks feature group and its feature group based on status
         this.allRacks.addLayer(marker);
-        if (state.status === "approved") {
+        if (status) {
             this.allApproved.addLayer(marker);
         }
-        else if (state.status === "not_approved") {
+        else if (!status) {
             this.allNotApproved.addLayer(marker);
         }
         

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -366,7 +366,7 @@ BikeMap.prototype.createMarker = function(state) {
         if (isApproved(state)) {
             this.allApproved.addLayer(marker);
         }
-        else (!isApproved(state)) {
+        else {
             this.allNotApproved.addLayer(marker);
         }
         

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -367,7 +367,7 @@ BikeMap.prototype.createMarker = function(state) {
         if (status) {
             this.allApproved.addLayer(marker);
         }
-        else if (!status) {
+        else (!status) {
             this.allNotApproved.addLayer(marker);
         }
         

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -143,7 +143,7 @@ BikeMap.prototype.onAuthStateChanged = function(user) {
         this.$signInButton.attr('hidden', true);
         
 
-        // first things first, reload the map TODO
+        // first things first, reload the map
         this.loadMap(user.uid); 
         
         
@@ -154,7 +154,6 @@ BikeMap.prototype.onAuthStateChanged = function(user) {
         // show sign in button
         this.$signInButton.removeAttr('hidden');
         
-        // TODO disable add bike rack and voting buttons
         // reload the map again, so that popup buttons can be updated
         this.loadMap();
     }
@@ -589,7 +588,7 @@ BikeMap.prototype.popupContent = function(state) {
      *     longitude: longitude (string),
      *     rack_id: rack_id (string), determine if a marker is a temporary marker
      *         or not by if they have a rack_id or not
-     *     user_id: user_id (string, empty? (or undefined) if user is not signed in)
+     *     user_id: user_id (string, empty string if user is not signed in)
     }*/
     if (state.address === null || state.address === undefined) {
         state.address = ""

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -582,8 +582,6 @@ BikeMap.prototype.arrowHTML = function(state) {
 BikeMap.prototype.popupContent = function(state) {
     let onlineStatus,
         voterStatus;
-
-    onlineStatus = Boolean(this.auth.currentUser);
     
     /* state : {
      *     address: address (string),
@@ -604,14 +602,14 @@ BikeMap.prototype.popupContent = function(state) {
                <div id="options">`
     
     // if user is online and this isn't a temporary marker include the submit button and the voting buttons
-    if (onlineStatus && state.rack_id) {
+    if (isLoggedIn(this) && isTemporary(state)) {
         
         let arrows = this.arrowHTML(state);
         //content += `<button id="submitButton" type="submit">Add Bike Rack</button>`
         content += arrows;
     }
     // if the user is online and this IS a temporary marker include only the submit button
-    else if (onlineStatus && !state.rack_id && state.address) {
+    else if (isLoggedIn(this) && !isTemporary(state) && state.address) {
         
         content += `<button id="submitButton" type="submit">Add Bike Rack</button>`
     }

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -360,15 +360,13 @@ BikeMap.prototype.createMarker = function(state) {
     else {
         // we didn't find a marker, make a new one
         marker = L.marker([state.latitude, state.longitude], {uniqueId: state.rack_id}); 
-        // Figure out marker's status
-        let status = state.upvote_count > state.downvote_count;
         // add marker to allRacks feature group and its feature group based on status
         this.allRacks.addLayer(marker);
         // true implies that this rack is approved
-        if (status) {
+        if (isApproved(state)) {
             this.allApproved.addLayer(marker);
         }
-        else (!status) {
+        else (!isApproved(state)) {
             this.allNotApproved.addLayer(marker);
         }
         


### PR DESCRIPTION
"Status" is still used when making requests to the database. The JavaScript code requests racks with status='approved' for example, and then on the server side, we determine the query requirements like so:
status_req = "r.upvote_count > r.downvote_count" if status == "approved" else "r.downvote_count > r.upvote_count"

where r is the bikeracks table
Resolves #85 