### PR TITLE
Filter

### DIFF
--- a/src/bikeracks/templates/base.html
+++ b/src/bikeracks/templates/base.html
@@ -96,17 +96,23 @@
                           </button>
                             <ul class="dropdown-menu">
                                   <li>
-                                    <input id="showApproved" name="showApproved"
+                                    <input id="showApproved"
+                                           name="showApproved"
                                            class="checkboxes"
-                                           type="checkbox" aria-label="Checkbox for showing approved bikeracks">
+                                           type="checkbox"
+                                           checked
+                                           aria-label="Checkbox for showing approved bikeracks">
                                     <label for="showApproved">Approved</label>
                                         
                                         
                                   </li>
                                   <li>
-                                    <input id="showNotApproved" name="showNotApproved"
+                                    <input id="showNotApproved"
+                                           name="showNotApproved"
                                            class="checkboxes"
-                                           type="checkbox" aria-label="Checkbox for showing not approved bikeracks">
+                                           type="checkbox"
+                                           checked
+                                           aria-label="Checkbox for showing not approved bikeracks">
                                     <label for="showNotApproved">Not Approved</label>
                                    
                                   </li>

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -412,7 +412,7 @@ BikeMap.prototype.removeMarkers = function(markerGroup) {
 
 BikeMap.prototype.toggleMarkers = function(status, selector, group) {
     
-    let markerGroup = status === "approved"? this.allApproved : this.allNotApproved;
+    let markerGroup = status === "approved" ? this.allApproved : this.allNotApproved;
     //let racksP = this.getRacks(status);
     // if the map is showing markers of status=status, remove them from map
     if (selector.attr('checked')) {

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -394,8 +394,6 @@ BikeMap.prototype.showMarkers = function(markerGroup) {
     markerGroup.eachLayer(function(layer) {
         // add the marker to the cluster group
         this.markers.addLayer(layer);
-        // add the marker to map
-        this.mymap.addLayer(layer);
     }.bind(this))
 }
 
@@ -404,8 +402,6 @@ BikeMap.prototype.removeMarkers = function(markerGroup) {
     markerGroup.eachLayer(function(layer) {
         // remove the marker from the cluster group
         this.markers.removeLayer(layer)
-        // remove the marker from the map
-        this.mymap.removeLayer(layer);
     }.bind(this));
 }
 

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -392,6 +392,9 @@ BikeMap.prototype.addMarker = function(marker) {
 BikeMap.prototype.showMarkers = function(markerGroup) {
     // show markers of markerGroup on map
     markerGroup.eachLayer(function(layer) {
+        // add the marker to the cluster group
+        this.markers.addLayer(layer);
+        // add the marker to map
         this.mymap.addLayer(layer);
     }.bind(this))
 }
@@ -399,6 +402,9 @@ BikeMap.prototype.showMarkers = function(markerGroup) {
 BikeMap.prototype.removeMarkers = function(markerGroup) {
     // remove markers only from map
     markerGroup.eachLayer(function(layer) {
+        // remove the marker from the cluster group
+        this.markers.removeLayer(layer)
+        // remove the marker from the map
         this.mymap.removeLayer(layer);
     }.bind(this));
 }

--- a/src/bikeracks/templates/scripts.js
+++ b/src/bikeracks/templates/scripts.js
@@ -406,17 +406,19 @@ BikeMap.prototype.removeMarkers = function(markerGroup) {
 
 BikeMap.prototype.toggleMarkers = function(status, selector, group) {
     
-    let racksP = this.getRacks(status);
+    let markerGroup = status === "approved"? this.allApproved : this.allNotApproved;
+    //let racksP = this.getRacks(status);
     // if the map is showing markers of status=status, remove them from map
-    if (selector.hasClass('onmap')) {
-        racksP.done((racks) => this.removeMarkers(group));
-        // remove class onmap
-        selector.removeClass('onmap');
+    if (selector.attr('checked')) {
+       this.removeMarkers(markerGroup);
+       // and uncheck
+       selector.removeAttr('checked')
     }
-    // if the map is now showing markers of status=status, add them to map
+    // if the map is not showing markers of status=status, add them to map
     else {
-        racksP.done((racks) => this.showMarkers(group));
-        selector.addClass('onmap');
+        this.showMarkers(markerGroup);
+        // and add the checked attribute
+        selector.attr('checked', true);
     }
 };
 


### PR DESCRIPTION
The initial state of the filter checkboxes should be checked. Resolves #103 
Marker cluster group was creating duplicates when filtering markers. Make sure to remove marker from cluster group when removing it from the map and adding it to the cluster group when adding it back to the map. Resolves #104
